### PR TITLE
Rework GetCompressedFileHeader and oodleDecompress, remove 2nd argument, refactor

### DIFF
--- a/source/FileExporter.cpp
+++ b/source/FileExporter.cpp
@@ -53,7 +53,7 @@ namespace HAYDEN
             if (thisFile.resourceFileCompressedSize != thisFile.resourceFileDecompressedSize)
             {
                 // decompress with Oodle DLL
-                auto decompressedData = oodleDecompress(compressedData, thisFile.resourceFileCompressedSize, thisFile.resourceFileDecompressedSize);
+                auto decompressedData = oodleDecompress(compressedData, thisFile.resourceFileDecompressedSize);
                 if (decompressedData.empty())
                     continue; // error
 

--- a/source/FileExporter.cpp
+++ b/source/FileExporter.cpp
@@ -39,7 +39,7 @@ namespace HAYDEN
         FILE* f = fopen(resourceFile.filename.c_str(), "rb");
         if (f == NULL)
         {
-            printf("Error: failed to open %s for reading.\n", resourceFile.filename.c_str());
+            fprintf(stderr, "Error: failed to open %s for reading.\n", resourceFile.filename.c_str());
             return;
         }
         
@@ -47,14 +47,13 @@ namespace HAYDEN
         for (uint64 i = 0; i < _ExportItems.size(); i++)
         {
             FileExportItem& thisFile = _ExportItems[i];
-            byte* compressedData = resourceFile.GetCompressedFileHeader(f, thisFile.resourceFileOffset, thisFile.resourceFileCompressedSize);
+            auto compressedData = resourceFile.GetEmbeddedFileHeader(f, thisFile.resourceFileOffset, thisFile.resourceFileCompressedSize);
 
             // check if decompression is necessary
             if (thisFile.resourceFileCompressedSize != thisFile.resourceFileDecompressedSize)
             {
                 // decompress with Oodle DLL
                 auto decompressedData = oodleDecompress(compressedData, thisFile.resourceFileCompressedSize, thisFile.resourceFileDecompressedSize);
-                delete[] compressedData;
                 if (decompressedData.empty())
                     continue; // error
 
@@ -63,7 +62,7 @@ namespace HAYDEN
             }
             else
             {
-                std::vector<byte> decompressedData(*compressedData, *compressedData + thisFile.resourceFileCompressedSize);
+                std::vector<byte> decompressedData(compressedData.begin(), compressedData.begin() + thisFile.resourceFileCompressedSize);
                 EmbeddedTGAHeader embeddedTGAHeader = resourceFile.ReadTGAHeader(decompressedData);
                 _TGAHeaderData.push_back(embeddedTGAHeader);
             }        

--- a/source/ResourceFile.cpp
+++ b/source/ResourceFile.cpp
@@ -16,13 +16,11 @@ namespace HAYDEN
     }
 
     // Reads embedded file headers into filestream
-    byte* ResourceFile::GetCompressedFileHeader(FILE* f, const uint64 fileOffset, const uint64 compressedSize) const
+    std::vector<byte> ResourceFile::GetEmbeddedFileHeader(FILE* f, const uint64 fileOffset, const uint64 compressedSize) const
     {
-        byte* compressedData = NULL;
-        compressedData = new byte[compressedSize];
-
+        std::vector<byte> compressedData(compressedSize);
         fseek(f, (long)fileOffset, SEEK_SET);
-        fread(compressedData, 1, compressedSize, f);
+        fread(compressedData.data(), 1, compressedSize, f);
         return compressedData;
     }
 
@@ -194,7 +192,7 @@ namespace HAYDEN
         FILE* f = fopen(filename.c_str(), "rb");
         if (f == NULL) 
         {
-            printf("Error: failed to open %s for reading.\n", filename.c_str());
+            fprintf(stderr, "Error: failed to open %s for reading.\n", filename.c_str());
             return;
         }
 

--- a/source/ResourceFile.h
+++ b/source/ResourceFile.h
@@ -93,7 +93,7 @@ namespace HAYDEN
             ResourceFile() {};
 
             // Helper Functions - ReadEmbeddedTGAHeaders()
-            byte* GetCompressedFileHeader(FILE* f, const uint64 fileOffset, const uint64 compressedSize) const;
+            std::vector<byte> GetEmbeddedFileHeader(FILE* f, const uint64 fileOffset, const uint64 compressedSize) const;
             EmbeddedTGAHeader ReadTGAHeader(const std::vector<byte> tgaDecompressedHeader) const;
 
             // Helper functions for constructor

--- a/source/SAMUEL.cpp
+++ b/source/SAMUEL.cpp
@@ -21,7 +21,7 @@ namespace HAYDEN
         }
         catch (...)
         {
-            printf("ERROR: Failed to load packagemapspec.json. \n");
+            fprintf(stderr, "Error: Failed to load packagemapspec.json.\n");
             return;
         }
     }
@@ -79,7 +79,7 @@ namespace HAYDEN
         }
         catch (...)
         {
-            printf("ERROR: Failed to read .resource file %s. \n", inputFile.c_str());
+            fprintf(stderr, "Error: Failed to read .resource file %s.\n", inputFile.c_str());
             return;
         }
 
@@ -91,7 +91,7 @@ namespace HAYDEN
         }
         catch (...)
         {
-            printf("ERROR: Failed to read .streamdb list from packagemapspec.json. \n");
+            fprintf(stderr, "Error: Failed to read .streamdb list from packagemapspec.json.\n");
             return;
         }
 
@@ -102,7 +102,7 @@ namespace HAYDEN
         }
         catch (...)
         {
-            printf("ERROR: Failed to read .streamdb file data. \n");
+            fprintf(stderr, "Error: Failed to read .streamdb file data.\n");
             return;
         }
         return;
@@ -115,13 +115,13 @@ namespace HAYDEN
     void SAMUEL::Init(const std::string basePath)
     {
         if (!fs::exists("oo2core_8_win64.dll")) {
-            printf("Error: Could not find oo2core_8_win64.dll in the current directory. \n");
+            fprintf(stderr, "Error: Could not find oo2core_8_win64.dll in the current directory.\n");
             exit(1);
         }
 
 #ifdef __linux__
         if (!fs::exists("liblinoodle.so")) {
-            printf("Error: Could not find liblinoodle.so in the current directory. \n");
+            fprintf(stderr, "Error: Could not find liblinoodle.so in the current directory.\n");
             exit(1);
         }
 #endif
@@ -133,16 +133,24 @@ namespace HAYDEN
 
 int main(int argc, char* argv[])
 {
-    printf("SAMUEL v0.1 by SamPT \n");
+    printf("SAMUEL v0.1 by SamPT\n");
 
-    if (argc == 1) {
-        printf("USAGE: SAMUEL resourceFile basePath \n");
+    if (argc < 2) {
+        printf("USAGE: SAMUEL resourceFile basePath\n");
         return 1;
     }
 
+    // Get base path from resource path
+    std::string resourcePath(argv[1]);
+    auto baseIndex = resourcePath.find("base");
+    if (baseIndex == std::string::npos) {
+        fprintf(stderr, "Error: Failed to get game's base path.\n");
+    }
+    std::string basePath = resourcePath.substr(0, baseIndex + 4);
+
     SAMUEL SAM;
-    SAM.Init(argv[2]);
-    SAM.LoadResource(argv[1]);
+    SAM.Init(basePath);
+    SAM.LoadResource(resourcePath);
     SAM.ExportAll();
     return 0;
 }

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -22,7 +22,7 @@ namespace HAYDEN
         return x;
     }
 
-    std::vector<byte> oodleDecompress(byte* compressedData, const uint64 compressedSize, const uint64 decompressedSize)
+    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 compressedSize, const uint64 decompressedSize)
     {
         std::vector<byte> output(decompressedSize + SAFE_SPACE);
         uint64 outbytes;
@@ -38,16 +38,16 @@ namespace HAYDEN
 
         if (!OodLZ_Decompress)
         {
-            printf("Error: failed to load oo2core_8_win64.dll.\n\n");
+            fprintf(stderr, "Error: failed to load oo2core_8_win64.dll.\n\n");
             return std::vector<byte>();
         }
 
         // Decompress using Oodle DLL
-        outbytes = OodLZ_Decompress(compressedData, compressedSize, output.data(), decompressedSize, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        outbytes = OodLZ_Decompress(compressedData.data(), compressedSize, output.data(), decompressedSize, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         
         if (!outbytes)
         {
-            printf("Error: failed to decompress with Oodle DLL.\n\n");
+            fprintf(stderr, "Error: failed to decompress with Oodle DLL.\n\n");
             return std::vector<byte>();
         }
 

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -22,7 +22,7 @@ namespace HAYDEN
         return x;
     }
 
-    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 compressedSize, const uint64 decompressedSize)
+    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 decompressedSize)
     {
         std::vector<byte> output(decompressedSize + SAFE_SPACE);
         uint64 outbytes;
@@ -43,7 +43,7 @@ namespace HAYDEN
         }
 
         // Decompress using Oodle DLL
-        outbytes = OodLZ_Decompress(compressedData.data(), compressedSize, output.data(), decompressedSize, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        outbytes = OodLZ_Decompress(compressedData.data(), compressedData.size(), output.data(), decompressedSize, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         
         if (!outbytes)
         {

--- a/source/Utilities.h
+++ b/source/Utilities.h
@@ -33,5 +33,5 @@ namespace HAYDEN
     uint64_t hexToInt64(const std::string hex); 
     void endianSwap(uint64& value); 
     
-    std::vector<byte> oodleDecompress(byte* compressedData, const uint64 compressedSize, const uint64 decompressedSize);
+    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 compressedSize, const uint64 decompressedSize);
 }

--- a/source/Utilities.h
+++ b/source/Utilities.h
@@ -33,5 +33,5 @@ namespace HAYDEN
     uint64_t hexToInt64(const std::string hex); 
     void endianSwap(uint64& value); 
     
-    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 compressedSize, const uint64 decompressedSize);
+    std::vector<byte> oodleDecompress(std::vector<byte> compressedData, const uint64 decompressedSize);
 }


### PR DESCRIPTION
Solves #10 and #11, makes error messages be printed to `stderr`, and makes oodleDecompress receive a byte vector instead of a pointer.