### PR TITLE
Use switch statement in DDSHeaderBuild constructor

### DIFF
--- a/source/DDSHeader.cpp
+++ b/source/DDSHeader.cpp
@@ -2,10 +2,10 @@
 
 namespace HAYDEN
 {
-    int DDSHeaderBuilder::ComputePitch(int width, int height, int decompressedSize, int imageType)
+    int DDSHeaderBuilder::ComputePitch(int width, int height, int decompressedSize, enum ImageType imageType)
     {
         int pitch = 0;
-        if (imageType == 7 || imageType == 3) // RG8, RGBA8
+        if (imageType == FMT_RG8 || imageType == FMT_RGBA8) // RG8, RGBA8
         {
             pitch = (width * 16 + 7) / 8;
         }
@@ -25,101 +25,71 @@ namespace HAYDEN
         return buffer;
     }
 
-    DDSHeaderBuilder::DDSHeaderBuilder(int width, int height, int decompressedSize, int imageType)
+    DDSHeaderBuilder::DDSHeaderBuilder(int width, int height, int decompressedSize, enum ImageType imageType)
     {
         _DDSHeader.ddsHeight = height;
         _DDSHeader.ddsWidth = width;
         _DDSHeader.ddsPitch = decompressedSize;
 
-        // Might want to make this a switch statement, not sure...
         // This checks imageTypes according to the frequency they are used in the game.
-        // If an imageType is rarely used, it is at the bottom of this list. 
-
-        // FMT_BC1_ZERO_ALPHA, FMT_BC1_SRGB, or FMT_BC1 (Linear)
-        if (imageType == 54 || imageType == 33 || imageType == 10)
+        // If an imageType is rarely used, it is at the bottom of this list.
+        switch (imageType)
         {
-            // use defaults
-            return;
+            case FMT_BC1_ZERO_ALPHA:
+            case FMT_BC1_SRGB:
+            case FMT_BC1_LINEAR:
+                // use defaults
+                return;
+            case FMT_BC4_LINEAR:
+                _DDSHeader.ddsType = 1429488450;    // BC4U
+                return;
+            case FMT_BC5_LINEAR:
+                _DDSHeader.ddsType = 1429553986;    // BC5U
+                return;
+            case FMT_BC7_SRGB:
+            case FMT_BC7_LINEAR:
+                _AppendDXT10 = 1;
+                _DDSHeader.ddsType = 808540228;     // DX10
+                return;
+            case FMT_BC3_SRGB:
+            case FMT_BC3_LINEAR:
+                _DDSHeader.ddsType = 894720068;     // DXT5
+                return;
+            case FMT_RGBA8:
+                _DDSHeader.ddsType = 0;
+                _DDSHeader.flags = 135183;          // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH | DDSD_PIXELFORMAT | DDSD_MIPMAPCOUNT
+                _DDSHeader.pfFlags = 65;            // DDPF_ALPHAPIXELS | DDPF_RGB
+                _DDSHeader.rgbBits = 32;
+                _DDSHeader.rBitMsk = 16711680;
+                _DDSHeader.gBitMsk = 65280;
+                _DDSHeader.bBitMsk = 255;
+                _DDSHeader.aBitMsk = -16777216;
+                _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
+                return;
+            case FMT_ALPHA:
+                _DDSHeader.ddsType = 0;
+                _DDSHeader.flags = 135183;
+                _DDSHeader.pfFlags = 2;             // DDPF_ALPHA
+                _DDSHeader.rgbBits = 8;
+                _DDSHeader.aBitMsk = 255;
+                _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
+                return;
+            case FMT_RG8:
+                _DDSHeader.ddsType = 0;
+                _DDSHeader.flags = 135183;          // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH | DDSD_PIXELFORMAT | DDSD_MIPMAPCOUNT
+                _DDSHeader.pfFlags = 131073;        // DDPF_ALPHAPIXELS | DDPF_LUMINANCE
+                _DDSHeader.rgbBits = 16;
+                _DDSHeader.rBitMsk = 255;
+                _DDSHeader.aBitMsk = 65280;
+                _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
+                return;
+            case FMT_BC6H_UF16:
+                _AppendDXT10 = 1;
+                _DDSHeader.ddsType = 808540228;     // DX10
+                _DDSHeaderDXT10.dxgiFormat = 95;    // DXGI_FORMAT_BC6H_UF16
+                return;
+            default:
+                return;
         }
-            
-        // FMT_BC4
-        if (imageType == 24)
-        {
-            _DDSHeader.ddsType = 1429488450;    // BC4U
-            return;
-        }
-
-        // FMT_BC5
-        if (imageType == 25)
-        {
-            _DDSHeader.ddsType = 1429553986;    // BC5U
-            return;
-        }
-
-        // FMT_BC7_SRGB or FMT_BC7 (Linear)
-        if (imageType == 35 || imageType == 23)
-        {
-            _AppendDXT10 = 1;
-            _DDSHeader.ddsType = 808540228;     // DX10
-            return;
-        }
-
-        // FMT_BC3_SRGB or FMT_BC3 (Linear)
-        if (imageType == 34 || imageType == 11)
-        {
-            _DDSHeader.ddsType = 894720068;     // DXT5
-            return;
-        }
-
-        // FMT_RGBA8
-        if (imageType == 3)
-        {
-            _DDSHeader.ddsType = 0;
-            _DDSHeader.flags = 135183;          // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH | DDSD_PIXELFORMAT | DDSD_MIPMAPCOUNT
-            _DDSHeader.pfFlags = 65;            // DDPF_ALPHAPIXELS | DDPF_RGB
-            _DDSHeader.rgbBits = 32;
-            _DDSHeader.rBitMsk = 16711680;
-            _DDSHeader.gBitMsk = 65280;
-            _DDSHeader.bBitMsk = 255;
-            _DDSHeader.aBitMsk = -16777216;
-            _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
-            return;
-        }
-
-        // FMT_ALPHA
-        if (imageType == 5)
-        {
-            _DDSHeader.ddsType = 0;
-            _DDSHeader.flags = 135183;
-            _DDSHeader.pfFlags = 2;             // DDPF_ALPHA
-            _DDSHeader.rgbBits = 8;
-            _DDSHeader.aBitMsk = 255;
-            _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
-            return;
-        }
-
-        // FMT_RG8
-        if (imageType == 7)
-        {
-            _DDSHeader.ddsType = 0;
-            _DDSHeader.flags = 135183;          // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PITCH | DDSD_PIXELFORMAT | DDSD_MIPMAPCOUNT
-            _DDSHeader.pfFlags = 131073;        // DDPF_ALPHAPIXELS | DDPF_LUMINANCE
-            _DDSHeader.rgbBits = 16;
-            _DDSHeader.rBitMsk = 255;
-            _DDSHeader.aBitMsk = 65280;
-            _DDSHeader.ddsPitch = ComputePitch(width, height, decompressedSize, imageType);
-            return;
-        }
-
-        // FMT_BC6H_UF16
-        if (imageType == 22)
-        {
-            _AppendDXT10 = 1;
-            _DDSHeader.ddsType = 808540228;     // DX10
-            _DDSHeaderDXT10.dxgiFormat = 95;    // DXGI_FORMAT_BC6H_UF16
-            return;
-        }
-
-        return;
     }
 }

--- a/source/DDSHeader.h
+++ b/source/DDSHeader.h
@@ -45,12 +45,29 @@ namespace HAYDEN
 		const int miscFlag2 = 0;		// DDS_ALPHA_MODE_UNKNOWN
 	};
 
+	enum ImageType
+    {
+        FMT_BC1_ZERO_ALPHA = 54,
+        FMT_BC7_SRGB = 35,
+        FMT_BC3_SRGB = 34,
+        FMT_BC1_SRGB = 33,
+        FMT_BC5_LINEAR = 25, 
+        FMT_BC4_LINEAR = 24, 
+        FMT_BC7_LINEAR = 23, 
+        FMT_BC6H_UF16 = 22, 
+        FMT_BC3_LINEAR = 11, 
+        FMT_BC1_LINEAR = 10,
+        FMT_RG8 = 7, 
+        FMT_ALPHA = 5, 
+        FMT_RGBA8 = 3
+    };
+
 	class DDSHeaderBuilder
 	{	
 		public:
-			int ComputePitch(int width, int height, int decompressedSize, int imageType);
+			int ComputePitch(int width, int height, int decompressedSize, enum ImageType imageType);
 			std::vector<byte> ConvertToByteVector();
-			DDSHeaderBuilder(int width, int height, int decompressedSize, int imageType);
+			DDSHeaderBuilder(int width, int height, int decompressedSize, enum ImageType imageType);
 			
 		private:
 			DDSHeader _DDSHeader;


### PR DESCRIPTION
Adds an enum for the DDS image type, and changes the DDSHeaderBuild to use a switch statement instead of if statements.