### PR TITLE
Fix linoodle runtime exception on Linux

### DIFF
--- a/source/core/Utilities.cpp
+++ b/source/core/Utilities.cpp
@@ -31,7 +31,7 @@ namespace HAYDEN
 #else
         // Copy oodle to current dir to prevent linoodle errors
         std::error_code ec;
-        fs::copy(oodlePath, fs::current_path());
+        fs::copy(oodlePath, fs::current_path(), ec);
         if (ec.value() != 0)
             return false;
 


### PR DESCRIPTION
Fixes the `std::runtime_exception` caused by linoodle failing to find the oodle dll.